### PR TITLE
Add repository map reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ It permits multiple travellers to follow the same trajectory asynchronously.
 
 ## Contributing
 - New implementations of the three underlying models described in the technical report are welcome.
+- For a high-level project overview including build, dependency, class diagrams and javadocs see <a href="https://sourcespy.com/github/nationalsecurityagencyfractalrabbit/">Reposotry Map</a>.
 
 ## Community
 - TBA


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/nationalsecurityagencyfractalrabbit/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.